### PR TITLE
Update composer.json to be save with php <= 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Wrapper for Magento2 ImportExport functionality, which exports products and customers from arrays",
   "homepage": "https://github.com/magento-hackathon/FireGento_FastSimpleExport",
   "require": {
-    "php": "~5.5.0|~5.6.0|~7.0.0"
+    "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0"
   },
   "type": "magento2-module",
   "license": "GPL-3.0",


### PR DESCRIPTION
Hey guys,

we should update this. Magento works already with PHP 7.2 and this plugin does as well.
If you guess that i haven't tested every edge case, you are probably correct. So feel free to give it a try ;)

Greets, Ulf 